### PR TITLE
FIX: Show `PostActions` only to authorized users and routing bug

### DIFF
--- a/src/app/project/[slug]/[boardSlug]/[postSlug]/page.tsx
+++ b/src/app/project/[slug]/[boardSlug]/[postSlug]/page.tsx
@@ -5,6 +5,8 @@ import PostCard from "@/components/project/post-card";
 import { getPost } from "@/lib/post/data";
 import { ArrowLeftIcon } from "@radix-ui/react-icons";
 import PostActions from "@/components/post/post-actions";
+import { getUserSession } from "@/auth";
+import { isProjectAdmin, isSuperuser } from "@/lib/permissions";
 
 export default async function Page({
     params,
@@ -12,11 +14,18 @@ export default async function Page({
     params: { slug: string; boardSlug: string; postSlug: string };
 }) {
     const { slug: projectSlug, boardSlug, postSlug } = params;
+    const session = await getUserSession();
     const post = await getPost(postSlug);
 
     if (!post) {
         notFound();
     }
+
+    const isAuthorized =
+        session?.user &&
+        ((await isSuperuser()) ||
+            (await isProjectAdmin(post.status.category.projectId)) ||
+            post.userId === session?.user.id);
 
     const boardUrl = `/project/${projectSlug}/${boardSlug}/`;
     const postUrl = `/project/${projectSlug}/${boardSlug}/${postSlug}`;
@@ -30,11 +39,13 @@ export default async function Page({
                     </Link>
                     <h3 className="text-2xl">View Post</h3>
                 </div>
-                <PostActions
-                    postId={post.id}
-                    postUrl={postUrl}
-                    boardUrl={boardUrl}
-                />
+                {isAuthorized && (
+                    <PostActions
+                        postId={post.id}
+                        postUrl={postUrl}
+                        boardUrl={boardUrl}
+                    />
+                )}
             </div>
             <div className="flex flex-wrap gap-8">
                 <PostCard post={post} baseLink="" linkInTitle={false} />

--- a/src/components/post/form.tsx
+++ b/src/components/post/form.tsx
@@ -53,7 +53,6 @@ export default function PostForm({
         let res;
         if (edit && post) {
             res = await updatePost(post.id, values);
-            router.replace(`${boardUrl}/${res.post?.slug}`);
         } else {
             res = await createPost(categoryId, values);
         }
@@ -61,6 +60,7 @@ export default function PostForm({
         if (!res) return;
         if (res.success) {
             toast({ title: edit ? "Post updated!" : "Post created!" });
+            router.replace(`${boardUrl}/${res.post?.slug}`);
             form.reset();
         } else {
             toast({ title: res.message });

--- a/src/lib/post/data.ts
+++ b/src/lib/post/data.ts
@@ -105,7 +105,10 @@ export async function getPost(postSlug: string) {
             status: {
                 include: {
                     category: {
-                        select: { title: true },
+                        select: {
+                            title: true,
+                            projectId: true,
+                        },
                     },
                 },
             },


### PR DESCRIPTION
This PR adds:

- A check to see if user is authorized to see post actions
- Bug fix for when non logged in user was redirected to invalid url after updating post