### PR TITLE
Feat: No projects text

### DIFF
--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -19,16 +19,18 @@ export default async function Page() {
                 )}
             </div>
             <div className="flex flex-wrap gap-8">
-                {projects.map((project) => {
-                    return (
-                        <ProjectCard
-                            key={project.id}
-                            title={project.title}
-                            slug={project?.slug || ""}
-                            description={project.description}
-                        />
-                    );
-                })}
+                {projects.length === 0
+                    ? "No projects found."
+                    : projects.map((project) => {
+                          return (
+                              <ProjectCard
+                                  key={project.id}
+                                  title={project.title}
+                                  slug={project?.slug || ""}
+                                  description={project.description}
+                              />
+                          );
+                      })}
             </div>
         </div>
     );

--- a/src/components/ui/header.tsx
+++ b/src/components/ui/header.tsx
@@ -16,7 +16,7 @@ export default async function Header({ className }: { className?: string }) {
             )}
         >
             <Link href={"/home"} className="text-2xl">
-                Feedboard
+                {process.env.INSTANCE_TITLE || "Feedboard"}
             </Link>
             <div className="flex items-center gap-4">
                 {session?.user ? (


### PR DESCRIPTION
This PR adds "No Projects found." text on the `/home` route if no projects are found. 
It also adds an environment variable `INSTANCE_TITLE` that is displayed in the header.