### PR TITLE
Fix: non unique slugs

### DIFF
--- a/src/lib/board/actions.ts
+++ b/src/lib/board/actions.ts
@@ -166,21 +166,21 @@ export async function deleteCategory(categoryId: string) {
 
 export async function createDefaultStatuses(categoryId: string) {
     try {
-        await Promise.all(
-            statusesData.map(async ({ title, colour, isDefault }) => {
-                const uniqueSlug = await generateUniqueSlug("status", title);
+        const createdStatuses = [];
+        for (const { title, colour, isDefault } of statusesData) {
+            const uniqueSlug = await generateUniqueSlug("status", title);
+            const status = await prisma.status.create({
+                data: {
+                    title,
+                    colour,
+                    categoryId,
+                    isDefault,
+                    slug: uniqueSlug,
+                },
+            });
+            createdStatuses.push(status);
+        }
 
-                return prisma.status.create({
-                    data: {
-                        title,
-                        colour,
-                        categoryId,
-                        isDefault,
-                        slug: uniqueSlug,
-                    },
-                });
-            }),
-        );
         return {
             success: true,
             message: "Default statuses created successfully.",

--- a/src/lib/project/actions.ts
+++ b/src/lib/project/actions.ts
@@ -48,27 +48,20 @@ export async function createProject(values: ProjectFormInputs) {
             },
         });
 
-        const categoryResults = await Promise.all(
-            categories.map(async (category) => {
-                const { success, message } =
-                    await createOrUpdateProjectCategory(project.id, category);
-                if (!success) {
-                    return {
-                        success: false,
-                        message,
-                    };
-                }
-            }),
-        );
+        const categoryResults = [];
+        for (const category of categories) {
+            const { success, message } = await createOrUpdateProjectCategory(
+                project.id,
+                category,
+            );
+            categoryResults.push({ success, message });
 
-        const failedCategory = categoryResults.find(
-            (result) => !result?.success,
-        );
-        if (failedCategory) {
-            return {
-                success: false,
-                message: "One or more category creation failed.",
-            };
+            if (!success) {
+                return {
+                    success: false,
+                    message: `Failed to create category: ${message}`,
+                };
+            }
         }
 
         return {
@@ -136,27 +129,20 @@ export async function updateProject(
             },
         });
 
-        const categoryResults = await Promise.all(
-            categories.map(async (category) => {
-                const { success, message } =
-                    await createOrUpdateProjectCategory(project.id, category);
-                if (!success) {
-                    return {
-                        success: false,
-                        message,
-                    };
-                }
-            }),
-        );
+        const categoryResults = [];
+        for (const category of categories) {
+            const { success, message } = await createOrUpdateProjectCategory(
+                project.id,
+                category,
+            );
+            categoryResults.push({ success, message });
 
-        const failedCategory = categoryResults.find(
-            (result) => !result?.success,
-        );
-        if (failedCategory) {
-            return {
-                success: false,
-                message: "One or more category updates failed.",
-            };
+            if (!success) {
+                return {
+                    success: false,
+                    message: `Failed to update category: ${message}`,
+                };
+            }
         }
 
         revalidatePath(`/project/${project.slug}/edit`);


### PR DESCRIPTION
This PR fixes statuses not being created due to non-unique slugs being generated.
It does so by removing `Promise.all` and using `for` loops instead.