### PR TITLE
Remove auto_stop_machines, auto_start_machines and min_machines_running

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -9,14 +9,11 @@ primary_region = 'sin'
 [build]
 
 [http_service]
-  internal_port = 3000
-  force_https = true
-  auto_stop_machines = true
-  auto_start_machines = true
-  min_machines_running = 0
-  processes = ['app']
+internal_port = 3000
+force_https = true
+processes = ['app']
 
 [[vm]]
-  memory = '1gb'
-  cpu_kind = 'shared'
-  cpus = 2
+memory = '1gb'
+cpu_kind = 'shared'
+cpus = 2


### PR DESCRIPTION
This PR removes the following settings from `fly.toml`:

auto_stop_machines = true
auto_start_machines = true
min_machines_running = 0