### PR TITLE
Add `orderBy` clauses

### DIFF
--- a/app/lib/home/data.ts
+++ b/app/lib/home/data.ts
@@ -1,6 +1,10 @@
 import prisma from "~/lib/prisma.server";
 
 export async function getProjects() {
-  const projects = await prisma.project.findMany();
+  const projects = await prisma.project.findMany({
+    orderBy: {
+      createdAt: "asc",
+    },
+  });
   return projects;
 }

--- a/app/lib/post/comment/data.ts
+++ b/app/lib/post/comment/data.ts
@@ -12,6 +12,9 @@ export async function getComments(postId: string, replyToId?: string) {
         select: { replies: true },
       },
     },
+    orderBy: {
+      createdAt: "desc",
+    },
   });
   return comments;
 }

--- a/app/lib/project/data.ts
+++ b/app/lib/project/data.ts
@@ -48,6 +48,9 @@ export async function getProject(slug: string) {
                 take: POSTS_PER_ROADMAP,
               },
             },
+            orderBy: {
+              createdAt: "asc",
+            },
           },
         },
         orderBy: {


### PR DESCRIPTION
This PR adds the `orderBy` clause to `getProject`, `getProjects`, and `getComments` data functions.